### PR TITLE
dplyr session tweaks

### DIFF
--- a/Sessions/2021_02_24_dplyr.Rmd
+++ b/Sessions/2021_02_24_dplyr.Rmd
@@ -21,10 +21,19 @@ library(tibble)
 
 In order to use `dplyr` functions you need to ensure your dataframe is in "tidy" format. This means in your dataframe each row represents an observation and each column represents a variable. This is also called "long format".
 
-We will use the `mtcars` dataset which is in tidy format to understand dplyr functions.
+We will use the `mtcars` (Motor Trend magazine car road tests) dataset which is in tidy format to understand dplyr functions.
 ```{r}
 head(mtcars)
 ```
+
+Tidyverse includes an enhancement to `data.frame`s called a "tibble" that are useful for interactive data analysis. Its most useful feature is that when entered in the command prompt on its own, a `tibble` will by default print out only its first 10 rows and only as many column as can be displayed on a single line. Use `as_tibble` to convert a normal `data.frame` to a `tibble`
+
+```{r}
+mtcars <- as_tibble(datasets::mtcars)
+mtcars
+```
+
+
 
 ### Summarising data
 
@@ -110,11 +119,10 @@ top_n(mtcars, 5, mpg) %>%
 **How do I subset a dataframe by columns?**
 </span>
 ```{r}
-select(mtcars, mpg, cyl) %>%
-  head()
+select(mtcars, mpg, cyl)
 
-# To exract columns as a vector:
-pull(mtcars, mpg, cyl)
+# To extract a column as a vector:
+pull(mtcars, mpg)
 ```
 
 <span style="color: darkblue;"> 
@@ -122,12 +130,11 @@ pull(mtcars, mpg, cyl)
 </span>
 
 ```{r}
-mutate(mtcars, gpm = 1/mpg) %>%
-  head()
+mutate(mtcars, gpm = 1/mpg)
+
 # Can input any vector, as long as it's the same length as number of rows in your data frame. eg:
-vector <- rep(1, nrow(mtcars))
-mutate(mtcars, random_vec = vector) %>%
-  head()
+a_vector <- rep(1, nrow(mtcars))
+mutate(mtcars, random_vec = a_vector)
 ```
 
 <span style="color: darkblue;"> 
@@ -135,25 +142,24 @@ mutate(mtcars, random_vec = vector) %>%
 </span>
 
 ```{r}
-transmute(mtcars, gpm = 1/mpg) %>%
-  head()
+transmute(mtcars, gpm = 1/mpg)
 ```
 
 <span style="color: darkblue;"> 
 **How do I apply a function to every column?**
 </span>
 
+The function to apply can either be supplied directly (`fun`) or as an anonymous ("lambda") function using the formula syntax (`~fun(.)`)
+
 ```{r}
-mutate_all(mtcars, funs(.*100)) %>% # note the use of . in funs
-  head()
+mutate_all(mtcars, ~.*100) # note the use of . in the lambda function
+
 # What if not all our columns were numeric? We can do this:
-mutate_if(mtcars, is.numeric, funs(.*100)) %>%
-  head()
+mutate_if(mtcars, is.numeric, ~.*100)
 
 # What if you want to log transform a few variables for example.
 # eg. log transform the mpg and cyl columns only:
-mutate_at(mtcars, vars(c(mpg, cyl)) , funs(log(.))) %>%
-  head
+mutate_at(mtcars, vars(c(mpg, cyl)) , log)
 
 ```
 
@@ -163,19 +169,20 @@ mutate_at(mtcars, vars(c(mpg, cyl)) , funs(log(.))) %>%
 </span>
 
 ```{r}
-rename(mtcars, miles_per_gallon=mpg) %>%
-  head()
+rename(mtcars, miles_per_gallon=mpg)
 
 # Be careful about names, avoid spaces. If you have have spaces use `` to enclose the variable name.
-rename(mtcars, `miles per gallon`=mpg) %>%
-  head()
+rename(mtcars, `miles per gallon`=mpg) 
 ```
 
 ### Row names
-Be aware that if you have a variable stored as a row name then that you want to work with then you need to move it to a collumn. The `tibble` package has a function for this.
+Be aware that if you have a variable stored as a row name then that you want to work with then you need to move it to a column. The `tibble` package has a function for this.
 ```{r}
-rownames_to_column(mtcars, var="Car") %>%
-  head()
+rownames_to_column(datasets::mtcars, var="Car") 
+```
+We can also do this conversion when making the `tibble`
+```{r}
+as_tibble(datasets::mtcars, rownames='Car')
 ```
 
 ### Combining Tables
@@ -184,9 +191,8 @@ rownames_to_column(mtcars, var="Car") %>%
 
 ```{r}
 # New dataframe:
-df <- select(mtcars, new_mpg=mpg)
-bind_cols(mtcars, df) %>% # BE SURE ROWS ALLIGN
-  head()
+dataf <- select(mtcars, new_mpg=mpg)
+bind_cols(mtcars, dataf) # BE SURE ROWS ALLIGN
 ```
 May be better to use a "mutating join" as that will match values with the rows they correspond to, ie. if your rows don't allign.
 These include: `left_join`,`right_join`, `inner_join` and `full_join`. 
@@ -195,7 +201,20 @@ Use the `by=` argument to specify the column(s) both data frames match on or a n
 Similarly, there are functions for rows. Such as `bind_rows`, `intersect`, `setdiff`, `union`.
 
 
+# Advantages and disadvantages of dplyr (and the "Tidy") system
 
+Pros:
+
+- Consistent grammar for extracting, filtering, viewing, and manipulating data tables.
+- [Verb-oriented data manipulation](https://dplyr.tidyverse.org/articles/base.html) what each processing step is aimed at doing
+- "Piping" approach makes it easier to build up operations one step at a time
+- Encourages copying data to a new data.frame when using mutations rather than modifying data in place, which can introduce errors in interactive analysis when lines of code are run out-of-order.
+
+Cons:
+
+- Function names, syntax, and defaults seem to change every few years, breaking old code.
+- Namespace conflicts with several standard R functions (`stats::filter`, `stats::lag`, `MASS::select`, `base::intersect`, `base::union`)
+- Extra syntax required for indirection, when you want to do something with a column whose name is stored in a variable rather than having to name the column directly. This happens for example when your script needs to select a column or create a new column but you don't know what the column is called until the script is run. 
 
 
 

--- a/Sessions/2021_02_24_dplyr.md
+++ b/Sessions/2021_02_24_dplyr.md
@@ -8,7 +8,7 @@ Data Transformation with ‘dplyr’
 sheets](https://rstudio.com/resources/cheatsheets/)*** *for a nice
 overview of functions in this package.*
 
------
+------------------------------------------------------------------------
 
 Load in packages:
 
@@ -24,20 +24,49 @@ in “tidy” format. This means in your dataframe each row represents an
 observation and each column represents a variable. This is also called
 “long format”.
 
-We will use the `mtcars` dataset which is in tidy format to understand
-dplyr functions.
+We will use the `mtcars` (Motor Trend magazine car road tests) dataset
+which is in tidy format to understand dplyr functions.
 
 ``` r
 head(mtcars)
 ```
 
-    ##                    mpg cyl disp  hp drat    wt  qsec vs am gear carb
-    ## Mazda RX4         21.0   6  160 110 3.90 2.620 16.46  0  1    4    4
-    ## Mazda RX4 Wag     21.0   6  160 110 3.90 2.875 17.02  0  1    4    4
-    ## Datsun 710        22.8   4  108  93 3.85 2.320 18.61  1  1    4    1
-    ## Hornet 4 Drive    21.4   6  258 110 3.08 3.215 19.44  1  0    3    1
-    ## Hornet Sportabout 18.7   8  360 175 3.15 3.440 17.02  0  0    3    2
-    ## Valiant           18.1   6  225 105 2.76 3.460 20.22  1  0    3    1
+    ## # A tibble: 6 x 11
+    ##     mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
+    ##   <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
+    ## 1  21       6   160   110  3.9   2.62  16.5     0     1     4     4
+    ## 2  21       6   160   110  3.9   2.88  17.0     0     1     4     4
+    ## 3  22.8     4   108    93  3.85  2.32  18.6     1     1     4     1
+    ## 4  21.4     6   258   110  3.08  3.22  19.4     1     0     3     1
+    ## 5  18.7     8   360   175  3.15  3.44  17.0     0     0     3     2
+    ## 6  18.1     6   225   105  2.76  3.46  20.2     1     0     3     1
+
+Tidyverse includes an enhancement to `data.frame`s called a “tibble”
+that are useful for interactive data analysis. Its most useful feature
+is that when entered in the command prompt on its own, a `tibble` will
+by default print out only its first 10 rows and only as many column as
+can be displayed on a single line. Use `as_tibble` to convert a normal
+`data.frame` to a `tibble`
+
+``` r
+mtcars <- as_tibble(datasets::mtcars)
+mtcars
+```
+
+    ## # A tibble: 32 x 11
+    ##      mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
+    ##    <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
+    ##  1  21       6  160    110  3.9   2.62  16.5     0     1     4     4
+    ##  2  21       6  160    110  3.9   2.88  17.0     0     1     4     4
+    ##  3  22.8     4  108     93  3.85  2.32  18.6     1     1     4     1
+    ##  4  21.4     6  258    110  3.08  3.22  19.4     1     0     3     1
+    ##  5  18.7     8  360    175  3.15  3.44  17.0     0     0     3     2
+    ##  6  18.1     6  225    105  2.76  3.46  20.2     1     0     3     1
+    ##  7  14.3     8  360    245  3.21  3.57  15.8     0     0     3     4
+    ##  8  24.4     4  147.    62  3.69  3.19  20       1     0     4     2
+    ##  9  22.8     4  141.    95  3.92  3.15  22.9     1     0     4     2
+    ## 10  19.2     6  168.   123  3.92  3.44  18.3     1     0     4     4
+    ## # … with 22 more rows
 
 ### Summarising data
 
@@ -75,8 +104,10 @@ summary(mtcars)
 summarise(mtcars, avg=mean(mpg))
 ```
 
-    ##        avg
-    ## 1 20.09062
+    ## # A tibble: 1 x 1
+    ##     avg
+    ##   <dbl>
+    ## 1  20.1
 
 ``` r
 # What's the best way to get the mean for all columns?
@@ -89,12 +120,17 @@ variables?** </span>
 grouped_mtcars <- mtcars %>%
                     group_by(cyl) %>%
                     summarise(avg=mean(mpg))
+```
+
+    ## `summarise()` ungrouping output (override with `.groups` argument)
+
+``` r
 grouped_mtcars
 ```
 
     ## # A tibble: 3 x 2
     ##     cyl   avg
-    ## * <dbl> <dbl>
+    ##   <dbl> <dbl>
     ## 1     4  26.7
     ## 2     6  19.7
     ## 3     8  15.1
@@ -106,9 +142,11 @@ above, with pipes, is easier to read than the following, without pipes:
 summarise(group_by(mtcars, cyl), avg = mean(mpg))
 ```
 
+    ## `summarise()` ungrouping output (override with `.groups` argument)
+
     ## # A tibble: 3 x 2
     ##     cyl   avg
-    ## * <dbl> <dbl>
+    ##   <dbl> <dbl>
     ## 1     4  26.7
     ## 2     6  19.7
     ## 3     8  15.1
@@ -122,13 +160,15 @@ logical criteria?** </span>
 filter(mtcars, mpg > 25)
 ```
 
-    ##                 mpg cyl  disp  hp drat    wt  qsec vs am gear carb
-    ## Fiat 128       32.4   4  78.7  66 4.08 2.200 19.47  1  1    4    1
-    ## Honda Civic    30.4   4  75.7  52 4.93 1.615 18.52  1  1    4    2
-    ## Toyota Corolla 33.9   4  71.1  65 4.22 1.835 19.90  1  1    4    1
-    ## Fiat X1-9      27.3   4  79.0  66 4.08 1.935 18.90  1  1    4    1
-    ## Porsche 914-2  26.0   4 120.3  91 4.43 2.140 16.70  0  1    5    2
-    ## Lotus Europa   30.4   4  95.1 113 3.77 1.513 16.90  1  1    5    2
+    ## # A tibble: 6 x 11
+    ##     mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
+    ##   <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
+    ## 1  32.4     4  78.7    66  4.08  2.2   19.5     1     1     4     1
+    ## 2  30.4     4  75.7    52  4.93  1.62  18.5     1     1     4     2
+    ## 3  33.9     4  71.1    65  4.22  1.84  19.9     1     1     4     1
+    ## 4  27.3     4  79      66  4.08  1.94  18.9     1     1     4     1
+    ## 5  26       4 120.     91  4.43  2.14  16.7     0     1     5     2
+    ## 6  30.4     4  95.1   113  3.77  1.51  16.9     1     1     5     2
 
 <span style="color: darkblue;"> **How do I remove rows with duplicate
 values?** </span>
@@ -138,10 +178,12 @@ values?** </span>
 distinct(mtcars, cyl)
 ```
 
-    ##                   cyl
-    ## Mazda RX4           6
-    ## Datsun 710          4
-    ## Hornet Sportabout   8
+    ## # A tibble: 3 x 1
+    ##     cyl
+    ##   <dbl>
+    ## 1     6
+    ## 2     4
+    ## 3     8
 
 ``` r
 # How do you keep the cases from the other columns?
@@ -157,13 +199,15 @@ mtcars %>%
   slice(10:15)
 ```
 
-    ##                     mpg cyl  disp  hp drat   wt  qsec vs am gear carb
-    ## Merc 280           19.2   6 167.6 123 3.92 3.44 18.30  1  0    4    4
-    ## Merc 280C          17.8   6 167.6 123 3.92 3.44 18.90  1  0    4    4
-    ## Merc 450SE         16.4   8 275.8 180 3.07 4.07 17.40  0  0    3    3
-    ## Merc 450SL         17.3   8 275.8 180 3.07 3.73 17.60  0  0    3    3
-    ## Merc 450SLC        15.2   8 275.8 180 3.07 3.78 18.00  0  0    3    3
-    ## Cadillac Fleetwood 10.4   8 472.0 205 2.93 5.25 17.98  0  0    3    4
+    ## # A tibble: 6 x 11
+    ##     mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
+    ##   <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
+    ## 1  19.2     6  168.   123  3.92  3.44  18.3     1     0     4     4
+    ## 2  17.8     6  168.   123  3.92  3.44  18.9     1     0     4     4
+    ## 3  16.4     8  276.   180  3.07  4.07  17.4     0     0     3     3
+    ## 4  17.3     8  276.   180  3.07  3.73  17.6     0     0     3     3
+    ## 5  15.2     8  276.   180  3.07  3.78  18       0     0     3     3
+    ## 6  10.4     8  472    205  2.93  5.25  18.0     0     0     3     4
 
 ``` r
 # last 5 rows:
@@ -171,13 +215,15 @@ mtcars %>%
   slice((nrow(mtcars)-5):nrow(mtcars))
 ```
 
-    ##                 mpg cyl  disp  hp drat    wt qsec vs am gear carb
-    ## Porsche 914-2  26.0   4 120.3  91 4.43 2.140 16.7  0  1    5    2
-    ## Lotus Europa   30.4   4  95.1 113 3.77 1.513 16.9  1  1    5    2
-    ## Ford Pantera L 15.8   8 351.0 264 4.22 3.170 14.5  0  1    5    4
-    ## Ferrari Dino   19.7   6 145.0 175 3.62 2.770 15.5  0  1    5    6
-    ## Maserati Bora  15.0   8 301.0 335 3.54 3.570 14.6  0  1    5    8
-    ## Volvo 142E     21.4   4 121.0 109 4.11 2.780 18.6  1  1    4    2
+    ## # A tibble: 6 x 11
+    ##     mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
+    ##   <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
+    ## 1  26       4 120.     91  4.43  2.14  16.7     0     1     5     2
+    ## 2  30.4     4  95.1   113  3.77  1.51  16.9     1     1     5     2
+    ## 3  15.8     8 351     264  4.22  3.17  14.5     0     1     5     4
+    ## 4  19.7     6 145     175  3.62  2.77  15.5     0     1     5     6
+    ## 5  15       8 301     335  3.54  3.57  14.6     0     1     5     8
+    ## 6  21.4     4 121     109  4.11  2.78  18.6     1     1     4     2
 
 ``` r
 # Is there a neater way of doing that?
@@ -191,12 +237,14 @@ top_n(mtcars, 5, mpg) %>%
   arrange(desc(mpg))
 ```
 
-    ##                 mpg cyl disp  hp drat    wt  qsec vs am gear carb
-    ## Toyota Corolla 33.9   4 71.1  65 4.22 1.835 19.90  1  1    4    1
-    ## Fiat 128       32.4   4 78.7  66 4.08 2.200 19.47  1  1    4    1
-    ## Honda Civic    30.4   4 75.7  52 4.93 1.615 18.52  1  1    4    2
-    ## Lotus Europa   30.4   4 95.1 113 3.77 1.513 16.90  1  1    5    2
-    ## Fiat X1-9      27.3   4 79.0  66 4.08 1.935 18.90  1  1    4    1
+    ## # A tibble: 5 x 11
+    ##     mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
+    ##   <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
+    ## 1  33.9     4  71.1    65  4.22  1.84  19.9     1     1     4     1
+    ## 2  32.4     4  78.7    66  4.08  2.2   19.5     1     1     4     1
+    ## 3  30.4     4  75.7    52  4.93  1.62  18.5     1     1     4     2
+    ## 4  30.4     4  95.1   113  3.77  1.51  16.9     1     1     5     2
+    ## 5  27.3     4  79      66  4.08  1.94  18.9     1     1     4     1
 
 ### Manipulating variables ie. columns
 
@@ -204,220 +252,329 @@ top_n(mtcars, 5, mpg) %>%
 columns?** </span>
 
 ``` r
-select(mtcars, mpg, cyl) %>%
-  head()
+select(mtcars, mpg, cyl)
 ```
 
-    ##                    mpg cyl
-    ## Mazda RX4         21.0   6
-    ## Mazda RX4 Wag     21.0   6
-    ## Datsun 710        22.8   4
-    ## Hornet 4 Drive    21.4   6
-    ## Hornet Sportabout 18.7   8
-    ## Valiant           18.1   6
+    ## # A tibble: 32 x 2
+    ##      mpg   cyl
+    ##    <dbl> <dbl>
+    ##  1  21       6
+    ##  2  21       6
+    ##  3  22.8     4
+    ##  4  21.4     6
+    ##  5  18.7     8
+    ##  6  18.1     6
+    ##  7  14.3     8
+    ##  8  24.4     4
+    ##  9  22.8     4
+    ## 10  19.2     6
+    ## # … with 22 more rows
 
 ``` r
-# To exract columns as a vector:
-pull(mtcars, mpg, cyl)
+# To extract a column as a vector:
+pull(mtcars, mpg)
 ```
 
-    ##    6    6    4    6    8    6    8    4    4    6    6    8    8    8    8    8 
-    ## 21.0 21.0 22.8 21.4 18.7 18.1 14.3 24.4 22.8 19.2 17.8 16.4 17.3 15.2 10.4 10.4 
-    ##    8    4    4    4    4    8    8    8    8    4    4    4    8    6    8    4 
-    ## 14.7 32.4 30.4 33.9 21.5 15.5 15.2 13.3 19.2 27.3 26.0 30.4 15.8 19.7 15.0 21.4
+    ##  [1] 21.0 21.0 22.8 21.4 18.7 18.1 14.3 24.4 22.8 19.2 17.8 16.4 17.3 15.2 10.4
+    ## [16] 10.4 14.7 32.4 30.4 33.9 21.5 15.5 15.2 13.3 19.2 27.3 26.0 30.4 15.8 19.7
+    ## [31] 15.0 21.4
 
 <span style="color: darkblue;"> **Which function should I use if I want
 to add a column to my dataframe?** </span>
 
 ``` r
-mutate(mtcars, gpm = 1/mpg) %>%
-  head()
+mutate(mtcars, gpm = 1/mpg)
 ```
 
-    ##                    mpg cyl disp  hp drat    wt  qsec vs am gear carb        gpm
-    ## Mazda RX4         21.0   6  160 110 3.90 2.620 16.46  0  1    4    4 0.04761905
-    ## Mazda RX4 Wag     21.0   6  160 110 3.90 2.875 17.02  0  1    4    4 0.04761905
-    ## Datsun 710        22.8   4  108  93 3.85 2.320 18.61  1  1    4    1 0.04385965
-    ## Hornet 4 Drive    21.4   6  258 110 3.08 3.215 19.44  1  0    3    1 0.04672897
-    ## Hornet Sportabout 18.7   8  360 175 3.15 3.440 17.02  0  0    3    2 0.05347594
-    ## Valiant           18.1   6  225 105 2.76 3.460 20.22  1  0    3    1 0.05524862
+    ## # A tibble: 32 x 12
+    ##      mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb    gpm
+    ##    <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>  <dbl>
+    ##  1  21       6  160    110  3.9   2.62  16.5     0     1     4     4 0.0476
+    ##  2  21       6  160    110  3.9   2.88  17.0     0     1     4     4 0.0476
+    ##  3  22.8     4  108     93  3.85  2.32  18.6     1     1     4     1 0.0439
+    ##  4  21.4     6  258    110  3.08  3.22  19.4     1     0     3     1 0.0467
+    ##  5  18.7     8  360    175  3.15  3.44  17.0     0     0     3     2 0.0535
+    ##  6  18.1     6  225    105  2.76  3.46  20.2     1     0     3     1 0.0552
+    ##  7  14.3     8  360    245  3.21  3.57  15.8     0     0     3     4 0.0699
+    ##  8  24.4     4  147.    62  3.69  3.19  20       1     0     4     2 0.0410
+    ##  9  22.8     4  141.    95  3.92  3.15  22.9     1     0     4     2 0.0439
+    ## 10  19.2     6  168.   123  3.92  3.44  18.3     1     0     4     4 0.0521
+    ## # … with 22 more rows
 
 ``` r
 # Can input any vector, as long as it's the same length as number of rows in your data frame. eg:
-vector <- rep(1, nrow(mtcars))
-mutate(mtcars, random_vec = vector) %>%
-  head()
+a_vector <- rep(1, nrow(mtcars))
+mutate(mtcars, random_vec = a_vector)
 ```
 
-    ##                    mpg cyl disp  hp drat    wt  qsec vs am gear carb random_vec
-    ## Mazda RX4         21.0   6  160 110 3.90 2.620 16.46  0  1    4    4          1
-    ## Mazda RX4 Wag     21.0   6  160 110 3.90 2.875 17.02  0  1    4    4          1
-    ## Datsun 710        22.8   4  108  93 3.85 2.320 18.61  1  1    4    1          1
-    ## Hornet 4 Drive    21.4   6  258 110 3.08 3.215 19.44  1  0    3    1          1
-    ## Hornet Sportabout 18.7   8  360 175 3.15 3.440 17.02  0  0    3    2          1
-    ## Valiant           18.1   6  225 105 2.76 3.460 20.22  1  0    3    1          1
+    ## # A tibble: 32 x 12
+    ##      mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb random_vec
+    ##    <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>      <dbl>
+    ##  1  21       6  160    110  3.9   2.62  16.5     0     1     4     4          1
+    ##  2  21       6  160    110  3.9   2.88  17.0     0     1     4     4          1
+    ##  3  22.8     4  108     93  3.85  2.32  18.6     1     1     4     1          1
+    ##  4  21.4     6  258    110  3.08  3.22  19.4     1     0     3     1          1
+    ##  5  18.7     8  360    175  3.15  3.44  17.0     0     0     3     2          1
+    ##  6  18.1     6  225    105  2.76  3.46  20.2     1     0     3     1          1
+    ##  7  14.3     8  360    245  3.21  3.57  15.8     0     0     3     4          1
+    ##  8  24.4     4  147.    62  3.69  3.19  20       1     0     4     2          1
+    ##  9  22.8     4  141.    95  3.92  3.15  22.9     1     0     4     2          1
+    ## 10  19.2     6  168.   123  3.92  3.44  18.3     1     0     4     4          1
+    ## # … with 22 more rows
 
 <span style="color: darkblue;"> **How do I create a new column but drop
 the rest?** </span>
 
 ``` r
-transmute(mtcars, gpm = 1/mpg) %>%
-  head()
+transmute(mtcars, gpm = 1/mpg)
 ```
 
-    ##                          gpm
-    ## Mazda RX4         0.04761905
-    ## Mazda RX4 Wag     0.04761905
-    ## Datsun 710        0.04385965
-    ## Hornet 4 Drive    0.04672897
-    ## Hornet Sportabout 0.05347594
-    ## Valiant           0.05524862
+    ## # A tibble: 32 x 1
+    ##       gpm
+    ##     <dbl>
+    ##  1 0.0476
+    ##  2 0.0476
+    ##  3 0.0439
+    ##  4 0.0467
+    ##  5 0.0535
+    ##  6 0.0552
+    ##  7 0.0699
+    ##  8 0.0410
+    ##  9 0.0439
+    ## 10 0.0521
+    ## # … with 22 more rows
 
 <span style="color: darkblue;"> **How do I apply a function to every
 column?** </span>
 
+The function to apply can either be supplied directly (`fun`) or as an
+anonymous (“lambda”) function using the formula syntax (`~fun(.)`)
+
 ``` r
-mutate_all(mtcars, funs(.*100)) %>% # note the use of . in funs
-  head()
+mutate_all(mtcars, ~.*100) # note the use of . in the lambda function
 ```
 
-    ## Warning: `funs()` is deprecated as of dplyr 0.8.0.
-    ## Please use a list of either functions or lambdas: 
-    ## 
-    ##   # Simple named list: 
-    ##   list(mean = mean, median = median)
-    ## 
-    ##   # Auto named with `tibble::lst()`: 
-    ##   tibble::lst(mean, median)
-    ## 
-    ##   # Using lambdas
-    ##   list(~ mean(., trim = .2), ~ median(., na.rm = TRUE))
-    ## This warning is displayed once every 8 hours.
-    ## Call `lifecycle::last_warnings()` to see where this warning was generated.
-
-    ##                    mpg cyl  disp    hp drat    wt qsec  vs  am gear carb
-    ## Mazda RX4         2100 600 16000 11000  390 262.0 1646   0 100  400  400
-    ## Mazda RX4 Wag     2100 600 16000 11000  390 287.5 1702   0 100  400  400
-    ## Datsun 710        2280 400 10800  9300  385 232.0 1861 100 100  400  100
-    ## Hornet 4 Drive    2140 600 25800 11000  308 321.5 1944 100   0  300  100
-    ## Hornet Sportabout 1870 800 36000 17500  315 344.0 1702   0   0  300  200
-    ## Valiant           1810 600 22500 10500  276 346.0 2022 100   0  300  100
+    ## # A tibble: 32 x 11
+    ##      mpg   cyl   disp    hp  drat    wt  qsec    vs    am  gear  carb
+    ##    <dbl> <dbl>  <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
+    ##  1 2100    600 16000  11000   390  262  1646      0   100   400   400
+    ##  2 2100    600 16000  11000   390  288. 1702      0   100   400   400
+    ##  3 2280    400 10800   9300   385  232. 1861    100   100   400   100
+    ##  4 2140    600 25800  11000   308  322. 1944.   100     0   300   100
+    ##  5 1870    800 36000  17500   315  344  1702      0     0   300   200
+    ##  6 1810.   600 22500  10500   276  346  2022    100     0   300   100
+    ##  7 1430    800 36000  24500   321  357  1584      0     0   300   400
+    ##  8 2440    400 14670.  6200   369  319  2000    100     0   400   200
+    ##  9 2280    400 14080.  9500   392  315  2290    100     0   400   200
+    ## 10 1920    600 16760  12300   392  344  1830    100     0   400   400
+    ## # … with 22 more rows
 
 ``` r
 # What if not all our columns were numeric? We can do this:
-mutate_if(mtcars, is.numeric, funs(.*100)) %>%
-  head()
+mutate_if(mtcars, is.numeric, ~.*100)
 ```
 
-    ##                    mpg cyl  disp    hp drat    wt qsec  vs  am gear carb
-    ## Mazda RX4         2100 600 16000 11000  390 262.0 1646   0 100  400  400
-    ## Mazda RX4 Wag     2100 600 16000 11000  390 287.5 1702   0 100  400  400
-    ## Datsun 710        2280 400 10800  9300  385 232.0 1861 100 100  400  100
-    ## Hornet 4 Drive    2140 600 25800 11000  308 321.5 1944 100   0  300  100
-    ## Hornet Sportabout 1870 800 36000 17500  315 344.0 1702   0   0  300  200
-    ## Valiant           1810 600 22500 10500  276 346.0 2022 100   0  300  100
+    ## # A tibble: 32 x 11
+    ##      mpg   cyl   disp    hp  drat    wt  qsec    vs    am  gear  carb
+    ##    <dbl> <dbl>  <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
+    ##  1 2100    600 16000  11000   390  262  1646      0   100   400   400
+    ##  2 2100    600 16000  11000   390  288. 1702      0   100   400   400
+    ##  3 2280    400 10800   9300   385  232. 1861    100   100   400   100
+    ##  4 2140    600 25800  11000   308  322. 1944.   100     0   300   100
+    ##  5 1870    800 36000  17500   315  344  1702      0     0   300   200
+    ##  6 1810.   600 22500  10500   276  346  2022    100     0   300   100
+    ##  7 1430    800 36000  24500   321  357  1584      0     0   300   400
+    ##  8 2440    400 14670.  6200   369  319  2000    100     0   400   200
+    ##  9 2280    400 14080.  9500   392  315  2290    100     0   400   200
+    ## 10 1920    600 16760  12300   392  344  1830    100     0   400   400
+    ## # … with 22 more rows
 
 ``` r
 # What if you want to log transform a few variables for example.
 # eg. log transform the mpg and cyl columns only:
-mutate_at(mtcars, vars(c(mpg, cyl)) , funs(log(.))) %>%
-  head
+mutate_at(mtcars, vars(c(mpg, cyl)) , log)
 ```
 
-    ##                        mpg      cyl disp  hp drat    wt  qsec vs am gear carb
-    ## Mazda RX4         3.044522 1.791759  160 110 3.90 2.620 16.46  0  1    4    4
-    ## Mazda RX4 Wag     3.044522 1.791759  160 110 3.90 2.875 17.02  0  1    4    4
-    ## Datsun 710        3.126761 1.386294  108  93 3.85 2.320 18.61  1  1    4    1
-    ## Hornet 4 Drive    3.063391 1.791759  258 110 3.08 3.215 19.44  1  0    3    1
-    ## Hornet Sportabout 2.928524 2.079442  360 175 3.15 3.440 17.02  0  0    3    2
-    ## Valiant           2.895912 1.791759  225 105 2.76 3.460 20.22  1  0    3    1
+    ## # A tibble: 32 x 11
+    ##      mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
+    ##    <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
+    ##  1  3.04  1.79  160    110  3.9   2.62  16.5     0     1     4     4
+    ##  2  3.04  1.79  160    110  3.9   2.88  17.0     0     1     4     4
+    ##  3  3.13  1.39  108     93  3.85  2.32  18.6     1     1     4     1
+    ##  4  3.06  1.79  258    110  3.08  3.22  19.4     1     0     3     1
+    ##  5  2.93  2.08  360    175  3.15  3.44  17.0     0     0     3     2
+    ##  6  2.90  1.79  225    105  2.76  3.46  20.2     1     0     3     1
+    ##  7  2.66  2.08  360    245  3.21  3.57  15.8     0     0     3     4
+    ##  8  3.19  1.39  147.    62  3.69  3.19  20       1     0     4     2
+    ##  9  3.13  1.39  141.    95  3.92  3.15  22.9     1     0     4     2
+    ## 10  2.95  1.79  168.   123  3.92  3.44  18.3     1     0     4     4
+    ## # … with 22 more rows
 
 <span style="color: darkblue;"> **How do I rename columns?** </span>
 
 ``` r
-rename(mtcars, miles_per_gallon=mpg) %>%
-  head()
+rename(mtcars, miles_per_gallon=mpg)
 ```
 
-    ##                   miles_per_gallon cyl disp  hp drat    wt  qsec vs am gear
-    ## Mazda RX4                     21.0   6  160 110 3.90 2.620 16.46  0  1    4
-    ## Mazda RX4 Wag                 21.0   6  160 110 3.90 2.875 17.02  0  1    4
-    ## Datsun 710                    22.8   4  108  93 3.85 2.320 18.61  1  1    4
-    ## Hornet 4 Drive                21.4   6  258 110 3.08 3.215 19.44  1  0    3
-    ## Hornet Sportabout             18.7   8  360 175 3.15 3.440 17.02  0  0    3
-    ## Valiant                       18.1   6  225 105 2.76 3.460 20.22  1  0    3
-    ##                   carb
-    ## Mazda RX4            4
-    ## Mazda RX4 Wag        4
-    ## Datsun 710           1
-    ## Hornet 4 Drive       1
-    ## Hornet Sportabout    2
-    ## Valiant              1
+    ## # A tibble: 32 x 11
+    ##    miles_per_gallon   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
+    ##               <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
+    ##  1             21       6  160    110  3.9   2.62  16.5     0     1     4     4
+    ##  2             21       6  160    110  3.9   2.88  17.0     0     1     4     4
+    ##  3             22.8     4  108     93  3.85  2.32  18.6     1     1     4     1
+    ##  4             21.4     6  258    110  3.08  3.22  19.4     1     0     3     1
+    ##  5             18.7     8  360    175  3.15  3.44  17.0     0     0     3     2
+    ##  6             18.1     6  225    105  2.76  3.46  20.2     1     0     3     1
+    ##  7             14.3     8  360    245  3.21  3.57  15.8     0     0     3     4
+    ##  8             24.4     4  147.    62  3.69  3.19  20       1     0     4     2
+    ##  9             22.8     4  141.    95  3.92  3.15  22.9     1     0     4     2
+    ## 10             19.2     6  168.   123  3.92  3.44  18.3     1     0     4     4
+    ## # … with 22 more rows
 
 ``` r
 # Be careful about names, avoid spaces. If you have have spaces use `` to enclose the variable name.
-rename(mtcars, `miles per gallon`=mpg) %>%
-  head()
+rename(mtcars, `miles per gallon`=mpg) 
 ```
 
-    ##                   miles per gallon cyl disp  hp drat    wt  qsec vs am gear
-    ## Mazda RX4                     21.0   6  160 110 3.90 2.620 16.46  0  1    4
-    ## Mazda RX4 Wag                 21.0   6  160 110 3.90 2.875 17.02  0  1    4
-    ## Datsun 710                    22.8   4  108  93 3.85 2.320 18.61  1  1    4
-    ## Hornet 4 Drive                21.4   6  258 110 3.08 3.215 19.44  1  0    3
-    ## Hornet Sportabout             18.7   8  360 175 3.15 3.440 17.02  0  0    3
-    ## Valiant                       18.1   6  225 105 2.76 3.460 20.22  1  0    3
-    ##                   carb
-    ## Mazda RX4            4
-    ## Mazda RX4 Wag        4
-    ## Datsun 710           1
-    ## Hornet 4 Drive       1
-    ## Hornet Sportabout    2
-    ## Valiant              1
+    ## # A tibble: 32 x 11
+    ##    `miles per gallo…   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
+    ##                <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
+    ##  1              21       6  160    110  3.9   2.62  16.5     0     1     4     4
+    ##  2              21       6  160    110  3.9   2.88  17.0     0     1     4     4
+    ##  3              22.8     4  108     93  3.85  2.32  18.6     1     1     4     1
+    ##  4              21.4     6  258    110  3.08  3.22  19.4     1     0     3     1
+    ##  5              18.7     8  360    175  3.15  3.44  17.0     0     0     3     2
+    ##  6              18.1     6  225    105  2.76  3.46  20.2     1     0     3     1
+    ##  7              14.3     8  360    245  3.21  3.57  15.8     0     0     3     4
+    ##  8              24.4     4  147.    62  3.69  3.19  20       1     0     4     2
+    ##  9              22.8     4  141.    95  3.92  3.15  22.9     1     0     4     2
+    ## 10              19.2     6  168.   123  3.92  3.44  18.3     1     0     4     4
+    ## # … with 22 more rows
 
 ### Row names
 
 Be aware that if you have a variable stored as a row name then that you
-want to work with then you need to move it to a collumn. The `tibble`
+want to work with then you need to move it to a column. The `tibble`
 package has a function for this.
 
 ``` r
-rownames_to_column(mtcars, var="Car") %>%
-  head()
+rownames_to_column(datasets::mtcars, var="Car") 
 ```
 
-    ##                 Car  mpg cyl disp  hp drat    wt  qsec vs am gear carb
-    ## 1         Mazda RX4 21.0   6  160 110 3.90 2.620 16.46  0  1    4    4
-    ## 2     Mazda RX4 Wag 21.0   6  160 110 3.90 2.875 17.02  0  1    4    4
-    ## 3        Datsun 710 22.8   4  108  93 3.85 2.320 18.61  1  1    4    1
-    ## 4    Hornet 4 Drive 21.4   6  258 110 3.08 3.215 19.44  1  0    3    1
-    ## 5 Hornet Sportabout 18.7   8  360 175 3.15 3.440 17.02  0  0    3    2
-    ## 6           Valiant 18.1   6  225 105 2.76 3.460 20.22  1  0    3    1
+    ##                    Car  mpg cyl  disp  hp drat    wt  qsec vs am gear carb
+    ## 1            Mazda RX4 21.0   6 160.0 110 3.90 2.620 16.46  0  1    4    4
+    ## 2        Mazda RX4 Wag 21.0   6 160.0 110 3.90 2.875 17.02  0  1    4    4
+    ## 3           Datsun 710 22.8   4 108.0  93 3.85 2.320 18.61  1  1    4    1
+    ## 4       Hornet 4 Drive 21.4   6 258.0 110 3.08 3.215 19.44  1  0    3    1
+    ## 5    Hornet Sportabout 18.7   8 360.0 175 3.15 3.440 17.02  0  0    3    2
+    ## 6              Valiant 18.1   6 225.0 105 2.76 3.460 20.22  1  0    3    1
+    ## 7           Duster 360 14.3   8 360.0 245 3.21 3.570 15.84  0  0    3    4
+    ## 8            Merc 240D 24.4   4 146.7  62 3.69 3.190 20.00  1  0    4    2
+    ## 9             Merc 230 22.8   4 140.8  95 3.92 3.150 22.90  1  0    4    2
+    ## 10            Merc 280 19.2   6 167.6 123 3.92 3.440 18.30  1  0    4    4
+    ## 11           Merc 280C 17.8   6 167.6 123 3.92 3.440 18.90  1  0    4    4
+    ## 12          Merc 450SE 16.4   8 275.8 180 3.07 4.070 17.40  0  0    3    3
+    ## 13          Merc 450SL 17.3   8 275.8 180 3.07 3.730 17.60  0  0    3    3
+    ## 14         Merc 450SLC 15.2   8 275.8 180 3.07 3.780 18.00  0  0    3    3
+    ## 15  Cadillac Fleetwood 10.4   8 472.0 205 2.93 5.250 17.98  0  0    3    4
+    ## 16 Lincoln Continental 10.4   8 460.0 215 3.00 5.424 17.82  0  0    3    4
+    ## 17   Chrysler Imperial 14.7   8 440.0 230 3.23 5.345 17.42  0  0    3    4
+    ## 18            Fiat 128 32.4   4  78.7  66 4.08 2.200 19.47  1  1    4    1
+    ## 19         Honda Civic 30.4   4  75.7  52 4.93 1.615 18.52  1  1    4    2
+    ## 20      Toyota Corolla 33.9   4  71.1  65 4.22 1.835 19.90  1  1    4    1
+    ## 21       Toyota Corona 21.5   4 120.1  97 3.70 2.465 20.01  1  0    3    1
+    ## 22    Dodge Challenger 15.5   8 318.0 150 2.76 3.520 16.87  0  0    3    2
+    ## 23         AMC Javelin 15.2   8 304.0 150 3.15 3.435 17.30  0  0    3    2
+    ## 24          Camaro Z28 13.3   8 350.0 245 3.73 3.840 15.41  0  0    3    4
+    ## 25    Pontiac Firebird 19.2   8 400.0 175 3.08 3.845 17.05  0  0    3    2
+    ## 26           Fiat X1-9 27.3   4  79.0  66 4.08 1.935 18.90  1  1    4    1
+    ## 27       Porsche 914-2 26.0   4 120.3  91 4.43 2.140 16.70  0  1    5    2
+    ## 28        Lotus Europa 30.4   4  95.1 113 3.77 1.513 16.90  1  1    5    2
+    ## 29      Ford Pantera L 15.8   8 351.0 264 4.22 3.170 14.50  0  1    5    4
+    ## 30        Ferrari Dino 19.7   6 145.0 175 3.62 2.770 15.50  0  1    5    6
+    ## 31       Maserati Bora 15.0   8 301.0 335 3.54 3.570 14.60  0  1    5    8
+    ## 32          Volvo 142E 21.4   4 121.0 109 4.11 2.780 18.60  1  1    4    2
+
+We can also do this conversion when making the `tibble`
+
+``` r
+as_tibble(datasets::mtcars, rownames='Car')
+```
+
+    ## # A tibble: 32 x 12
+    ##    Car           mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
+    ##    <chr>       <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
+    ##  1 Mazda RX4    21       6  160    110  3.9   2.62  16.5     0     1     4     4
+    ##  2 Mazda RX4 …  21       6  160    110  3.9   2.88  17.0     0     1     4     4
+    ##  3 Datsun 710   22.8     4  108     93  3.85  2.32  18.6     1     1     4     1
+    ##  4 Hornet 4 D…  21.4     6  258    110  3.08  3.22  19.4     1     0     3     1
+    ##  5 Hornet Spo…  18.7     8  360    175  3.15  3.44  17.0     0     0     3     2
+    ##  6 Valiant      18.1     6  225    105  2.76  3.46  20.2     1     0     3     1
+    ##  7 Duster 360   14.3     8  360    245  3.21  3.57  15.8     0     0     3     4
+    ##  8 Merc 240D    24.4     4  147.    62  3.69  3.19  20       1     0     4     2
+    ##  9 Merc 230     22.8     4  141.    95  3.92  3.15  22.9     1     0     4     2
+    ## 10 Merc 280     19.2     6  168.   123  3.92  3.44  18.3     1     0     4     4
+    ## # … with 22 more rows
 
 ### Combining Tables
 
-`dply` also has functions for combining data frames:
+`dplyr` also has functions for combining data frames:
 
 ``` r
 # New dataframe:
-df <- select(mtcars, new_mpg=mpg)
-bind_cols(mtcars, df) %>% # BE SURE ROWS ALLIGN
-  head()
+dataf <- select(mtcars, new_mpg=mpg)
+bind_cols(mtcars, dataf) # BE SURE ROWS ALLIGN
 ```
 
-    ##                    mpg cyl disp  hp drat    wt  qsec vs am gear carb new_mpg
-    ## Mazda RX4         21.0   6  160 110 3.90 2.620 16.46  0  1    4    4    21.0
-    ## Mazda RX4 Wag     21.0   6  160 110 3.90 2.875 17.02  0  1    4    4    21.0
-    ## Datsun 710        22.8   4  108  93 3.85 2.320 18.61  1  1    4    1    22.8
-    ## Hornet 4 Drive    21.4   6  258 110 3.08 3.215 19.44  1  0    3    1    21.4
-    ## Hornet Sportabout 18.7   8  360 175 3.15 3.440 17.02  0  0    3    2    18.7
-    ## Valiant           18.1   6  225 105 2.76 3.460 20.22  1  0    3    1    18.1
+    ## # A tibble: 32 x 12
+    ##      mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb new_mpg
+    ##    <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>   <dbl>
+    ##  1  21       6  160    110  3.9   2.62  16.5     0     1     4     4    21  
+    ##  2  21       6  160    110  3.9   2.88  17.0     0     1     4     4    21  
+    ##  3  22.8     4  108     93  3.85  2.32  18.6     1     1     4     1    22.8
+    ##  4  21.4     6  258    110  3.08  3.22  19.4     1     0     3     1    21.4
+    ##  5  18.7     8  360    175  3.15  3.44  17.0     0     0     3     2    18.7
+    ##  6  18.1     6  225    105  2.76  3.46  20.2     1     0     3     1    18.1
+    ##  7  14.3     8  360    245  3.21  3.57  15.8     0     0     3     4    14.3
+    ##  8  24.4     4  147.    62  3.69  3.19  20       1     0     4     2    24.4
+    ##  9  22.8     4  141.    95  3.92  3.15  22.9     1     0     4     2    22.8
+    ## 10  19.2     6  168.   123  3.92  3.44  18.3     1     0     4     4    19.2
+    ## # … with 22 more rows
 
 May be better to use a “mutating join” as that will match values with
-the rows they correspond to. These include: `left_join`,`right_join`,
-`inner_join` and `full_join`. Use the `by=` argument to specify the
-column(s) both data frames match on or a named vector if the columns
-have different names in each data frame.
+the rows they correspond to, ie. if your rows don’t allign. These
+include: `left_join`,`right_join`, `inner_join` and `full_join`. Use the
+`by=` argument to specify the column(s) both data frames match on or a
+named vector if the columns have different names in each data frame.
 
 Similarly, there are functions for rows. Such as `bind_rows`,
 `intersect`, `setdiff`, `union`.
+
+Advantages and disadvantages of dplyr (and the “Tidy”) system
+=============================================================
+
+Pros:
+
+-   Consistent grammar for extracting, filtering, viewing, and
+    manipulating data tables.
+-   [Verb-oriented data
+    manipulation](https://dplyr.tidyverse.org/articles/base.html) what
+    each processing step is aimed at doing
+-   “Piping” approach makes it easier to build up operations one step at
+    a time
+-   Encourages copying data to a new data.frame when using mutations
+    rather than modifying data in place, which can introduce errors in
+    interactive analysis when lines of code are run out-of-order.
+
+Cons:
+
+-   Function names, syntax, and defaults seem to change every few years,
+    breaking old code.
+-   Namespace conflicts with several standard R functions
+    (`stats::filter`, `stats::lag`, `MASS::select`, `base::intersect`,
+    `base::union`)
+-   Extra syntax required for indirection, when you want to do something
+    with a column whose name is stored in a variable rather than having
+    to name the column directly. This happens for example when your
+    script needs to select a column or create a new column but you don’t
+    know what the column is called until the script is run.


### PR DESCRIPTION
Small changes to the code for the `dplyr` session, mainly converting the `mtcars` table into a `tibble`. Also updated the syntax for the `mutate_at` examples since `funs()` has been deprecated.

Added a list of pros and cons for discussion. 